### PR TITLE
Fix querySelector issue with class containing special characters

### DIFF
--- a/src/aiaio/app/static/script.js
+++ b/src/aiaio/app/static/script.js
@@ -59,7 +59,7 @@ function handleWebSocketMessage(data) {
             // Find and update the specific conversation's summary
             const conversationElement = document.querySelector(`[data-conversation-id="${data.conversation_id}"]`);
             if (conversationElement) {
-                const summaryElement = conversationElement.querySelector('.text-[10px].text-gray-600');
+                const summaryElement = conversationElement.querySelector('.text-\\[10px\\].text-gray-500');
                 if (summaryElement) {
                     summaryElement.textContent = data.summary || 'No summary';
                 }


### PR DESCRIPTION
This PR fixes an issue where `querySelector` was failing due to unescaped special characters in the class name.  

### **Changes Made:**  
- Updated the selector from:  
  ```js
  conversationElement.querySelector('.text-[10px].text-gray-600');
  ```  
  to:  
  ```js
  conversationElement.querySelector('.text-\\[10px\\].text-gray-500');
  ```  
- Properly escaped `[` and `]` in the class name to ensure it works as expected.  
- Updated `.text-gray-600` to `.text-gray-500` cause the html used the other one.

### **Reason for Change:**  
The previous selector was invalid due to unescaped square brackets, causing `querySelector` to throw an error. This fix ensures the selection works correctly.  

Let me know if any adjustments are needed! 
