### PR TITLE
Dynamic confirmation modal to replace delete chat and future use

### DIFF
--- a/src/aiaio/app/templates/index.html
+++ b/src/aiaio/app/templates/index.html
@@ -1051,6 +1051,27 @@
             </form>
         </div>
     </div>
+    <!-- Delete Confirmation Modal (universal usecase) -->
+    <div id="confirmation-modal"
+        class="fixed inset-0 bg-black bg-opacity-50 hidden flex items-center justify-center z-50">
+        <div class="bg-white dark:bg-gray-800 rounded-lg p-6 w-96 max-w-[90%]" onclick="event.stopPropagation()">
+            <h3 id="confirmation-title" class="text-lg font-semibold mb-4"></h3>
+            <p id="confirmation-message" class="text-sm text-gray-600 dark:text-gray-300"></p>
+
+            <input type="hidden" id="confirmation-action" value="">
+            <input type="hidden" id="confirmation-id" value="">
+
+            <div class="flex justify-end gap-2 mt-4">
+                <button id="cancel-action" type="button" onclick="closeConfirmationModal()"
+                    class="px-4 py-2 text-sm bg-gray-200 dark:bg-gray-700 rounded-lg hover:bg-gray-300 dark:hover:bg-gray-600">
+                    Cancel
+                </button>
+                <button id="confirm-action" class="px-4 py-2 text-sm text-white rounded-lg">
+                    Confirm
+                </button>
+            </div>
+        </div>
+    </div>
 </body>
 
 </html>


### PR DESCRIPTION
- Dynamic confirmation modal to replace browser based modal for delete conversation
- Support dynamic themes (danger (red) for deletions, primary (blue) for regular actions).
- Added support for HTML in confirmation messages

<img width="2560" alt="image" src="https://github.com/user-attachments/assets/4c9124a6-432e-4bff-9d89-39f2b67f1c81" />

<img width="2556" alt="image" src="https://github.com/user-attachments/assets/8bfa0f61-b61f-4952-a77b-4a6afa2aa8f3" />

